### PR TITLE
ringfs_scan calling free on invalid addresses

### DIFF
--- a/ringfs.c
+++ b/ringfs.c
@@ -206,7 +206,7 @@ int ringfs_scan(struct ringfs *fs)
 
         /* Detect and fix partially erased sectors. */
         if (header.status == SECTOR_ERASING || header.status == SECTOR_ERASED) {
-            _sector_free(fs, addr);
+            _sector_free(fs, sector);
             header.status = SECTOR_FREE;
         }
 


### PR DESCRIPTION
Ringfs_scan was calling _sector_free with the sector address instead of the sector number. This was causing reads and writes to erroneous addresses to NOR flash. These addresses are often outside of the usable range of the NOR flash leading to undefined behavior.