### PR TITLE
Initialize flashsim flash contents to 0xFF on creation.

### DIFF
--- a/tests/flashsim.c
+++ b/tests/flashsim.c
@@ -31,11 +31,26 @@ struct flashsim *flashsim_open(const char *name, int size, int sector_size)
 {
     struct flashsim *sim = malloc(sizeof(struct flashsim));
 
+    int file_exists = access(name, F_OK) != -1;
+
     sim->size = size;
     sim->sector_size = sector_size;
-    sim->fh = fopen(name, "w+");
+    sim->fh = fopen(name, file_exists ? "rb+" : "wb+");
     assert(sim->fh != NULL);
     assert(ftruncate(fileno(sim->fh), size) == 0);
+
+    if(!file_exists)
+    {
+        void *empty = malloc(sim->sector_size);
+        memset(empty, 0xff, sim->sector_size);
+
+        for(int address=0; address<size; address+=sector_size)
+        {
+            assert(fwrite(empty, 1, sim->sector_size, sim->fh) == (size_t) sim->sector_size);
+        }
+
+        free(empty);
+    }
 
     return sim;
 }


### PR DESCRIPTION
This mimics the behavior of a physical flash where 0xFF is the erased state.