### PR TITLE
Change ringfs_init return type from int to void.

### DIFF
--- a/ringfs.c
+++ b/ringfs.c
@@ -141,7 +141,7 @@ static void _loc_advance_slot(struct ringfs *fs, struct ringfs_loc *loc)
 
 /* And here we go. */
 
-int ringfs_init(struct ringfs *fs, struct ringfs_flash_partition *flash, uint32_t version, int object_size)
+void ringfs_init(struct ringfs *fs, struct ringfs_flash_partition *flash, uint32_t version, int object_size)
 {
     /* Copy arguments to instance. */
     fs->flash = flash;
@@ -151,8 +151,6 @@ int ringfs_init(struct ringfs *fs, struct ringfs_flash_partition *flash, uint32_
     /* Precalculate commonly used values. */
     fs->slots_per_sector = (fs->flash->sector_size - sizeof(struct sector_header)) /
                            (sizeof(struct slot_header) + fs->object_size);
-
-    return 0;
 }
 
 int ringfs_format(struct ringfs *fs)

--- a/ringfs.h
+++ b/ringfs.h
@@ -84,9 +84,8 @@ struct ringfs {
  * @param version Object version. Should be incremented whenever the object's
  *                semantics or size change in a backwards-incompatible way.
  * @param object_size Size of one stored object, in bytes.
- * @returns Zero on success, -1 on failure.
  */
-int ringfs_init(struct ringfs *fs, struct ringfs_flash_partition *flash, uint32_t version, int object_size);
+void ringfs_init(struct ringfs *fs, struct ringfs_flash_partition *flash, uint32_t version, int object_size);
 
 /**
  * Format the flash memory.

--- a/tests/pyringfs.py
+++ b/tests/pyringfs.py
@@ -47,7 +47,7 @@ class StructRingFS(Structure):
 class libringfs(GenericLibrary):
     dllname = './ringfs.so'
     functions = [
-        ['ringfs_init', [POINTER(StructRingFS), POINTER(StructRingFSFlashPartition), c_uint32, c_int], c_int],
+        ['ringfs_init', [POINTER(StructRingFS), POINTER(StructRingFSFlashPartition), c_uint32, c_int], None],
         ['ringfs_format', [POINTER(StructRingFS)], c_int],
         ['ringfs_scan', [POINTER(StructRingFS)], c_int],
         ['ringfs_capacity', [POINTER(StructRingFS)], c_int],


### PR DESCRIPTION
It only had one exit path and it was to return 0. As long as there aren't any more paths added it might as well return void to keep it simpler.